### PR TITLE
Use module.exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export default from './devTools';
+module.exports = require('./devTools').default;


### PR DESCRIPTION
If we use `require`, this module will return `{ default: ..., __esModule: true }`, so we should use `module.exports = require('...').default` to solve it.