### PR TITLE
Fix unhandled exceptions displaying the react native red exception screen

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -46,6 +46,10 @@ function init(options) {
   if (socket) socket.disconnect();
   socket = socketCluster.connect(options && options.port ? options : socketOptions);
 
+  socket.on('error', function(err){
+   console.error(err);
+  });
+
   socket.emit('login', 'master', (err, channelName) => {
     if (err) { console.error(err); return; }
     channel = socket.subscribe(channelName);


### PR DESCRIPTION
Hi,

If you don't have the server started react native on android will display a red exception window saying "connection hung up", this pull request redirects the unhandled exception into the console.

Cheers,
Matt