### PR TITLE
Set default hostname if port is set

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -44,6 +44,9 @@ function handleMessages(message) {
 function init(options) {
   if (channel) channel.unwatch();
   if (socket) socket.disconnect();
+  if (options && options.port && !options.hostname) {
+    options.hostname = 'localhost';
+  }
   socket = socketCluster.connect(options && options.port ? options : socketOptions);
 
   socket.on('error', function (err) {


### PR DESCRIPTION
If I haven't set `hostname`, will throw the following error:

```
Uncaught SyntaxError: Failed to construct 'WebSocket': The URL 'ws://:5678/socketcluster/' is invalid.
```