### PR TITLE
Add optional filters to reduce noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Name                  | Description
 `name`                | Instance name to be showed in the app.
 `hostname`            | If `port` is specified, default value is `localhost`.
 `port`                | Local host's port.
-`blacklist`           | Array of action type strings to exclude
-`whitelist`           | Array of action type strings to include
+`filters`             | Map of arrays named `whitelist` or `blacklist` to filter action types.
+
 
 All props are optional. You have to provide at least `port` property to use `localhost` instead of `remotedev.io` server.
 
@@ -68,7 +68,7 @@ export default function configureStore(initialState) {
   return createStore(
     rootReducer,
     initialState,
-    devTools({ hostname: 'localhost', port: 8000, name: 'Android app' })
+    devTools({ hostname: 'localhost', port: 8000, name: 'Android app', filters: { blacklist: ['EFFECT_RESOLVED'] }})
   );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Name                  | Description
 `name`                | Instance name to be showed in the app.
 `hostname`            | If `port` is specified, default value is `localhost`.
 `port`                | Local host's port.
+`blacklist`           | Array of action type strings to exclude
+`whitelist`           | Array of action type strings to include
 
 All props are optional. You have to provide at least `port` property to use `localhost` instead of `remotedev.io` server.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-redux-devtools",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Relay Redux actions to remote Redux DevTools.",
   "main": "lib/index.js",
   "files": [

--- a/src/devTools.js
+++ b/src/devTools.js
@@ -13,29 +13,31 @@ let filters = {};
 
 function isMonitored(actionType) {
   return (
-    filters.whitelist && actionType.match(filters.whitelist.join('|')) ||
-    filters.blacklist && !actionType.match(filters.blacklist.join('|'))
+    !actionType ||
+    (!filters.whitelist && !filters.blacklist) ||
+    (filters.whitelist && actionType.match(filters.whitelist.join('|'))) ||
+    (filters.blacklist && !actionType.match(filters.blacklist.join('|')))
   );
 }
 
 
 function relay(type, state, action, nextActionId) {
-  if (isMonitored(type)) {
-    setTimeout(() => {
-      const message = {
-        payload: state ? stringify(state) : '',
-        action: action ? stringify(action) : '',
-        nextActionId: nextActionId || '',
-        type,
-        id: socket.id,
-        name: instanceName,
-        init: shouldInit
-      };
-      if (shouldInit) shouldInit = false;
+  setTimeout(() => {
+    const message = {
+      payload: state ? stringify(state) : '',
+      action: action ? stringify(action) : '',
+      nextActionId: nextActionId || '',
+      type,
+      id: socket.id,
+      name: instanceName,
+      init: shouldInit
+    };
+    if (shouldInit) shouldInit = false;
 
+    if (!action || (action && action.action && isMonitored(action.action.type))) {
       socket.emit(socket.id ? 'log' : 'log-noid', message);
-    }, 0);
-  }
+    }
+  }, 0);
 }
 
 

--- a/src/devTools.js
+++ b/src/devTools.js
@@ -21,7 +21,7 @@ function isMonitored(actionType) {
 }
 
 
-function relay(type, state, action, nextActionId, allowStateFilter = false) {
+function relay(type, state, action, nextActionId) {
   if (!action || (action && action.action && isMonitored(action.action.type))) {
     setTimeout(() => {
       const message = {


### PR DESCRIPTION
This PR allows the optional passing of either a whitelist or blacklist array which can be used to reduce the action data logged to devtools.

I've recently started using redux-saga in my React Native app and it dispatches a large number of `EFFECT_*` actions which I don't necessarily need to see. I imagine there are other 3rd party libs that behave similarly. 

Inspiration came from https://github.com/zalmoxisus/redux-devtools-filter-actions