### PR TITLE
Warn instead of erroring when connection fails

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -65,7 +65,7 @@ function init(options) {
   });
 
   socket.emit('login', 'master', (err, channelName) => {
-    if (err) { console.error(err); return; }
+    if (err) { console.warn(err); return; }
     channel = socket.subscribe(channelName);
     channel.watch(handleMessages);
     socket.on(channelName, handleMessages);


### PR DESCRIPTION
Currently, if the remote devtools aren't able to access the server they log an error. This shows up as a prominent redbox in React Native, blocking the ability to interact with the app (see https://github.com/zalmoxisus/remote-redux-devtools/issues/4).

Since not connecting to the redux debug server isn't an app-crashing event, this would be more appropriate as a YellowBox, which is triggered by `console.warn`. This way a user can also ignore that error (in the case where they know that the devtools won't be able to connect and are ok with that, such as running on a device or with a local server that isn't running).