### PR TITLE
Remote monitoring in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ In order to make it simple to use, by default, the module and the monitor app co
 
 Name                  | Description
 -------------         | -------------
-`name`                | Instance name to be showed in the app.
-`hostname`            | If `port` is specified, default value is `localhost`.
-`port`                | Local host's port.
-`filters`             | Map of arrays named `whitelist` or `blacklist` to filter action types.
-`maxAge`              | Number of maximum allowed actions to be stored on the history tree, the oldest actions are removed once maxAge is reached. Default is `30`.
+`name`                | *String* representing the instance name to be shown on the remote monitor.
+`realtime`            | *Boolean* specifies whether to allow communicating with the remote monitor. By default is `process.env.NODE_ENV === 'development'`. 
+`hostname`            | *String* used for [`remotedev-server`](https://github.com/zalmoxisus/remotedev-server). If `port` is specified, default value is `localhost`.
+`port`                | *Number* used for [`remotedev-server`](https://github.com/zalmoxisus/remotedev-server). Local host's port.
+`filters`             | *Map of arrays* named `whitelist` or `blacklist` to filter action types.
+`maxAge`              | *Number* of maximum allowed actions to be stored on the history tree, the oldest actions are removed once maxAge is reached. Default is `30`.
 
 
 All props are optional. You have to provide at least `port` property to use `localhost` instead of `remotedev.io` server.
@@ -75,7 +76,11 @@ export default function configureStore(initialState) {
   return createStore(
     rootReducer,
     initialState,
-    devTools({ name: 'Android app', hostname: 'localhost', port: 8000, maxAge: 30, filters: { blacklist: ['EFFECT_RESOLVED'] }})
+    devTools({
+      name: 'Android app', realtime: true,
+      hostname: 'localhost', port: 8000,
+      maxAge: 30, filters: { blacklist: ['EFFECT_RESOLVED'] }
+      })
   );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Name                  | Description
 `filters`             | *Map of arrays* named `whitelist` or `blacklist` to filter action types.
 `maxAge`              | *Number* of maximum allowed actions to be stored on the history tree, the oldest actions are removed once maxAge is reached. Default is `30`.
 `startOn`             | *String* or *Array of strings* indicating an action or a list of actions, which should start remote monitoring (when `realtime` is `false`). 
+`stopOn`              | *String* or *Array of strings* indicating an action or a list of actions, which should stop remote monitoring. 
 
 All props are optional. You have to provide at least `port` property to use `localhost` instead of `remotedev.io` server.
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ In order to make it simple to use, by default, the module and the monitor app co
 Name                  | Description
 -------------         | -------------
 `name`                | *String* representing the instance name to be shown on the remote monitor.
-`realtime`            | *Boolean* specifies whether to allow communicating with the remote monitor. By default is `process.env.NODE_ENV === 'development'`. 
+`realtime`            | *Boolean* specifies whether to allow remote monitoring. By default is `process.env.NODE_ENV === 'development'`. 
 `hostname`            | *String* used for [`remotedev-server`](https://github.com/zalmoxisus/remotedev-server). If `port` is specified, default value is `localhost`.
 `port`                | *Number* used for [`remotedev-server`](https://github.com/zalmoxisus/remotedev-server). Local host's port.
 `filters`             | *Map of arrays* named `whitelist` or `blacklist` to filter action types.
 `maxAge`              | *Number* of maximum allowed actions to be stored on the history tree, the oldest actions are removed once maxAge is reached. Default is `30`.
-
+`startOn`             | *String* or *Array of strings* indicating an action or a list of actions, which should start remote monitoring (when `realtime` is `false`). 
 
 All props are optional. You have to provide at least `port` property to use `localhost` instead of `remotedev.io` server.
 

--- a/examples/counter/store/configureStore.js
+++ b/examples/counter/store/configureStore.js
@@ -7,7 +7,7 @@ import reducer from '../reducers';
 export default function configureStore(initialState) {
   const finalCreateStore = compose(
     applyMiddleware(invariant(), thunk),
-    devTools()
+    devTools({ realtime: true })
   )(createStore);
 
   const store = finalCreateStore(reducer, initialState);

--- a/examples/router/store/configureStore.js
+++ b/examples/router/store/configureStore.js
@@ -8,7 +8,7 @@ import rootReducer from '../reducers';
 export default function configureStore(initialState) {
   let finalCreateStore = compose(
     reduxReactRouter({ createHistory }),
-    devTools()
+    devTools({ realtime: true })
   )(createStore);
 
   const store = finalCreateStore(rootReducer, initialState);

--- a/examples/todomvc/store/configureStore.js
+++ b/examples/todomvc/store/configureStore.js
@@ -3,7 +3,7 @@ import devTools from 'remote-redux-devtools';
 import rootReducer from '../reducers';
 
 export default function configureStore(initialState) {
-  const store = devTools()(createStore)(rootReducer, initialState);
+  const store = devTools({ realtime: true })(createStore)(rootReducer, initialState);
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers

--- a/examples/toggle-monitoring/.babelrc
+++ b/examples/toggle-monitoring/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [ "es2015", "stage-0", "react" ]
+}

--- a/examples/toggle-monitoring/actions/counter.js
+++ b/examples/toggle-monitoring/actions/counter.js
@@ -1,0 +1,34 @@
+export const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
+export const DECREMENT_COUNTER = 'DECREMENT_COUNTER';
+
+export function increment() {
+  return {
+    type: INCREMENT_COUNTER
+  };
+}
+
+export function decrement() {
+  return {
+    type: DECREMENT_COUNTER
+  };
+}
+
+export function incrementIfOdd() {
+  return (dispatch, getState) => {
+    const { counter } = getState();
+
+    if (counter % 2 === 0) {
+      return;
+    }
+
+    dispatch(increment());
+  };
+}
+
+export function incrementAsync(delay = 1000) {
+  return dispatch => {
+    setTimeout(() => {
+      dispatch(increment());
+    }, delay);
+  };
+}

--- a/examples/toggle-monitoring/actions/monitoring.js
+++ b/examples/toggle-monitoring/actions/monitoring.js
@@ -1,0 +1,14 @@
+export const START_MONITORING = 'START_MONITORING';
+export const STOP_MONITORING = 'STOP_MONITORING';
+
+export function startMonitoring() {
+  return {
+    type: START_MONITORING
+  };
+}
+
+export function stopMonitoring() {
+  return {
+    type: STOP_MONITORING
+  };
+}

--- a/examples/toggle-monitoring/components/Counter.js
+++ b/examples/toggle-monitoring/components/Counter.js
@@ -1,0 +1,30 @@
+import React, { Component, PropTypes } from 'react';
+
+class Counter extends Component {
+  render() {
+    const { startMonitoring, stopMonitoring, increment, decrement, counter } = this.props;
+    return (
+      <p>
+        Clicked: {counter} times
+        {' '}
+        <button onClick={increment}>+</button>
+        {' '}
+        <button onClick={decrement}>-</button>
+        {' '}
+        <button onClick={startMonitoring}>Start monitoring</button>
+        {' '}
+        <button onClick={stopMonitoring}>Stop monitoring</button>
+      </p>
+    );
+  }
+}
+
+Counter.propTypes = {
+  startMonitoring: PropTypes.func.isRequired,
+  stopMonitoring: PropTypes.func.isRequired,
+  increment: PropTypes.func.isRequired,
+  decrement: PropTypes.func.isRequired,
+  counter: PropTypes.number.isRequired
+};
+
+export default Counter;

--- a/examples/toggle-monitoring/containers/App.js
+++ b/examples/toggle-monitoring/containers/App.js
@@ -1,0 +1,17 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import Counter from '../components/Counter';
+import * as CounterActions from '../actions/counter';
+import * as MonitorActions from '../actions/monitoring';
+
+function mapStateToProps(state) {
+  return {
+    counter: state.counter
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({ ...CounterActions, ...MonitorActions}, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Counter);

--- a/examples/toggle-monitoring/index.html
+++ b/examples/toggle-monitoring/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redux counter example</title>
+    <style>
+      html, body, #root, #container {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+      #container > p {
+        padding: 10px;
+        margin: auto;
+        font: 20px Arial;
+      }
+      button {
+        padding: 5px 15px;
+        font: bold 16px Arial;
+        cursor: pointer;
+      }
+      iframe  {
+        width: 100%;
+        height: calc(100% - 55px);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root">
+    </div>
+    <script src="/static/bundle.js"></script>
+  </body>
+</html>

--- a/examples/toggle-monitoring/index.js
+++ b/examples/toggle-monitoring/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from 'react-dom';
+import { Provider } from 'react-redux';
+import App from './containers/App';
+import configureStore from './store/configureStore';
+
+const store = configureStore();
+
+render(
+  <div id="container">
+    <Provider store={store}>
+      <App />
+    </Provider>
+    <iframe src="http://remotedev.io/local/" />
+  </div>,
+  document.getElementById('root')
+);

--- a/examples/toggle-monitoring/package.json
+++ b/examples/toggle-monitoring/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "redux-counter-example",
+  "version": "0.0.0",
+  "description": "Redux counter example",
+  "scripts": {
+    "start": "node server.js",
+    "test": "NODE_ENV=test mocha --recursive --compilers js:babel-core/register --require ./test/setup.js",
+    "test:watch": "npm test -- --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rackt/redux.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/rackt/redux/issues"
+  },
+  "homepage": "http://rackt.github.io/redux",
+  "dependencies": {
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "react-redux": "^4.0.0",
+    "redux": "^3.0.0",
+    "redux-thunk": "^0.1.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.3.15",
+    "babel-loader": "^6.2.0",
+    "babel-plugin-react-transform": "^2.0.0-beta1",
+    "babel-polyfill": "^6.3.14",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
+    "expect": "^1.6.0",
+    "express": "^4.13.3",
+    "jsdom": "^5.6.1",
+    "mocha": "^2.2.5",
+    "node-libs-browser": "^0.5.2",
+    "react-addons-test-utils": "^0.14.0",
+    "react-transform-hmr": "^1.0.0",
+    "redux-immutable-state-invariant": "^1.1.1",
+    "webpack": "^1.9.11",
+    "webpack-dev-middleware": "^1.2.0",
+    "webpack-hot-middleware": "^2.2.0"
+  }
+}

--- a/examples/toggle-monitoring/reducers/counter.js
+++ b/examples/toggle-monitoring/reducers/counter.js
@@ -1,0 +1,12 @@
+import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../actions/counter';
+
+export default function counter(state = 0, action) {
+  switch (action.type) {
+  case INCREMENT_COUNTER:
+    return state + 1;
+  case DECREMENT_COUNTER:
+    return state - 1;
+  default:
+    return state;
+  }
+}

--- a/examples/toggle-monitoring/reducers/index.js
+++ b/examples/toggle-monitoring/reducers/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import counter from './counter';
+
+const rootReducer = combineReducers({
+  counter
+});
+
+export default rootReducer;

--- a/examples/toggle-monitoring/server.js
+++ b/examples/toggle-monitoring/server.js
@@ -1,0 +1,23 @@
+var webpack = require('webpack');
+var webpackDevMiddleware = require('webpack-dev-middleware');
+var webpackHotMiddleware = require('webpack-hot-middleware');
+var config = require('./webpack.config');
+
+var app = new require('express')();
+var port = 4001;
+
+var compiler = webpack(config);
+app.use(webpackDevMiddleware(compiler, { noInfo: true, publicPath: config.output.publicPath }));
+app.use(webpackHotMiddleware(compiler));
+
+app.get("/", function(req, res) {
+  res.sendFile(__dirname + '/index.html');
+});
+
+app.listen(port, function(error) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.info("==> 🌎  Listening on port %s. Open up http://localhost:%s/ in your browser.", port, port);
+  }
+});

--- a/examples/toggle-monitoring/store/configureStore.js
+++ b/examples/toggle-monitoring/store/configureStore.js
@@ -1,0 +1,24 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunk from 'redux-thunk';
+import invariant from 'redux-immutable-state-invariant';
+import devTools from 'remote-redux-devtools';
+import reducer from '../reducers';
+
+export default function configureStore(initialState) {
+  const finalCreateStore = compose(
+    applyMiddleware(invariant(), thunk),
+    devTools({ realtime: false, startOn: 'START_MONITORING', stopOn: 'STOP_MONITORING' })
+  )(createStore);
+
+  const store = finalCreateStore(reducer, initialState);
+
+  if (module.hot) {
+    // Enable Webpack hot module replacement for reducers
+    module.hot.accept('../reducers', () => {
+      const nextReducer = require('../reducers');
+      store.replaceReducer(nextReducer);
+    });
+  }
+
+  return store;
+}

--- a/examples/toggle-monitoring/test/actions/counter.spec.js
+++ b/examples/toggle-monitoring/test/actions/counter.spec.js
@@ -1,0 +1,76 @@
+import expect from 'expect';
+import { applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import * as actions from '../../actions/counter';
+
+const middlewares = [thunk];
+
+/*
+ * Creates a mock of Redux store with middleware.
+ */
+function mockStore(getState, expectedActions, onLastAction) {
+  if (!Array.isArray(expectedActions)) {
+    throw new Error('expectedActions should be an array of expected actions.');
+  }
+  if (typeof onLastAction !== 'undefined' && typeof onLastAction !== 'function') {
+    throw new Error('onLastAction should either be undefined or function.');
+  }
+
+  function mockStoreWithoutMiddleware() {
+    return {
+      getState() {
+        return typeof getState === 'function' ?
+          getState() :
+          getState;
+      },
+
+      dispatch(action) {
+        const expectedAction = expectedActions.shift();
+        expect(action).toEqual(expectedAction);
+        if (onLastAction && !expectedActions.length) {
+          onLastAction();
+        }
+        return action;
+      }
+    };
+  }
+
+  const mockStoreWithMiddleware = applyMiddleware(
+    ...middlewares
+  )(mockStoreWithoutMiddleware);
+
+  return mockStoreWithMiddleware();
+}
+
+describe('actions', () => {
+  it('increment should create increment action', () => {
+    expect(actions.increment()).toEqual({ type: actions.INCREMENT_COUNTER });
+  });
+
+  it('decrement should create decrement action', () => {
+    expect(actions.decrement()).toEqual({ type: actions.DECREMENT_COUNTER });
+  });
+
+  it('incrementIfOdd should create increment action', (done) => {
+    const expectedActions = [
+      { type: actions.INCREMENT_COUNTER }
+    ];
+    const store = mockStore({ counter: 1 }, expectedActions, done);
+    store.dispatch(actions.incrementIfOdd());
+  });
+
+  it('incrementIfOdd shouldnt create increment action if counter is even', (done) => {
+    const expectedActions = [];
+    const store = mockStore({ counter: 2 }, expectedActions);
+    store.dispatch(actions.incrementIfOdd());
+    done();
+  });
+
+  it('incrementAsync should create increment action', (done) => {
+    const expectedActions = [
+      { type: actions.INCREMENT_COUNTER }
+    ];
+    const store = mockStore({ counter: 0 }, expectedActions, done);
+    store.dispatch(actions.incrementAsync(100));
+  });
+});

--- a/examples/toggle-monitoring/test/components/Counter.spec.js
+++ b/examples/toggle-monitoring/test/components/Counter.spec.js
@@ -1,0 +1,51 @@
+import expect from 'expect';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import Counter from '../../components/Counter';
+
+function setup() {
+  const actions = {
+    increment: expect.createSpy(),
+    incrementIfOdd: expect.createSpy(),
+    incrementAsync: expect.createSpy(),
+    decrement: expect.createSpy()
+  };
+  const component = TestUtils.renderIntoDocument(<Counter counter={1} {...actions} />);
+  return {
+    component: component,
+    actions: actions,
+    buttons: TestUtils.scryRenderedDOMComponentsWithTag(component, 'button'),
+    p: TestUtils.findRenderedDOMComponentWithTag(component, 'p')
+  };
+}
+
+describe('Counter component', () => {
+  it('should display count', () => {
+    const { p } = setup();
+    expect(p.textContent).toMatch(/^Clicked: 1 times/);
+  });
+
+  it('first button should call increment', () => {
+    const { buttons, actions } = setup();
+    TestUtils.Simulate.click(buttons[0]);
+    expect(actions.increment).toHaveBeenCalled();
+  });
+
+  it('second button should call decrement', () => {
+    const { buttons, actions } = setup();
+    TestUtils.Simulate.click(buttons[1]);
+    expect(actions.decrement).toHaveBeenCalled();
+  });
+
+  it('third button should call incrementIfOdd', () => {
+    const { buttons, actions } = setup();
+    TestUtils.Simulate.click(buttons[2]);
+    expect(actions.incrementIfOdd).toHaveBeenCalled();
+  });
+
+  it('fourth button should call incrementAsync', () => {
+    const { buttons, actions } = setup();
+    TestUtils.Simulate.click(buttons[3]);
+    expect(actions.incrementAsync).toHaveBeenCalled();
+  });
+});

--- a/examples/toggle-monitoring/test/containers/App.spec.js
+++ b/examples/toggle-monitoring/test/containers/App.spec.js
@@ -1,0 +1,53 @@
+import expect from 'expect';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import { Provider } from 'react-redux';
+import App from '../../containers/App';
+import configureStore from '../../store/configureStore';
+
+function setup(initialState) {
+  const store = configureStore(initialState);
+  const app = TestUtils.renderIntoDocument(
+    <Provider store={store}>
+      <App />
+    </Provider>
+  );
+  return {
+    app: app,
+    buttons: TestUtils.scryRenderedDOMComponentsWithTag(app, 'button'),
+    p: TestUtils.findRenderedDOMComponentWithTag(app, 'p')
+  };
+}
+
+describe('containers', () => {
+  describe('App', () => {
+    it('should display initial count', () => {
+      const { p } = setup();
+      expect(p.textContent).toMatch(/^Clicked: 0 times/);
+    });
+
+    it('should display updated count after increment button click', () => {
+      const { buttons, p } = setup();
+      TestUtils.Simulate.click(buttons[0]);
+      expect(p.textContent).toMatch(/^Clicked: 1 times/);
+    });
+
+    it('should display updated count after decrement button click', () => {
+      const { buttons, p } = setup();
+      TestUtils.Simulate.click(buttons[1]);
+      expect(p.textContent).toMatch(/^Clicked: -1 times/);
+    });
+
+    it('shouldnt change if even and if odd button clicked', () => {
+      const { buttons, p } = setup();
+      TestUtils.Simulate.click(buttons[2]);
+      expect(p.textContent).toMatch(/^Clicked: 0 times/);
+    });
+
+    it('should change if odd and if odd button clicked', () => {
+      const { buttons, p } = setup({ counter: 1 });
+      TestUtils.Simulate.click(buttons[2]);
+      expect(p.textContent).toMatch(/^Clicked: 2 times/);
+    });
+  });
+});

--- a/examples/toggle-monitoring/test/reducers/counter.spec.js
+++ b/examples/toggle-monitoring/test/reducers/counter.spec.js
@@ -1,0 +1,23 @@
+import expect from 'expect';
+import counter from '../../reducers/counter';
+import { INCREMENT_COUNTER, DECREMENT_COUNTER } from '../../actions/counter';
+
+describe('reducers', () => {
+  describe('counter', () => {
+    it('should handle initial state', () => {
+      expect(counter(undefined, {})).toBe(0);
+    });
+
+    it('should handle INCREMENT_COUNTER', () => {
+      expect(counter(1, { type: INCREMENT_COUNTER })).toBe(2);
+    });
+
+    it('should handle DECREMENT_COUNTER', () => {
+      expect(counter(1, { type: DECREMENT_COUNTER })).toBe(0);
+    });
+
+    it('should handle unknown action type', () => {
+      expect(counter(1, { type: 'unknown' })).toBe(1);
+    });
+  });
+});

--- a/examples/toggle-monitoring/test/setup.js
+++ b/examples/toggle-monitoring/test/setup.js
@@ -1,0 +1,5 @@
+import { jsdom } from 'jsdom';
+
+global.document = jsdom('<!doctype html><html><body></body></html>');
+global.window = document.defaultView;
+global.navigator = global.window.navigator;

--- a/examples/toggle-monitoring/webpack.config.js
+++ b/examples/toggle-monitoring/webpack.config.js
@@ -1,0 +1,42 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  devtool: 'cheap-module-eval-source-map',
+  entry: [
+    'webpack-hot-middleware/client',
+    './index'
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/static/'
+  },
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
+  ],
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      loaders: ['babel'],
+      exclude: /node_modules/,
+      include: __dirname
+    }]
+  }
+};
+
+var src = path.join(__dirname, '..', '..', 'src');
+var nodeModules = path.join(__dirname, '..', '..', 'node_modules');
+var fs = require('fs');
+if (fs.existsSync(src) && fs.existsSync(nodeModules)) {
+  // Resolve to source
+  module.exports.resolve = { alias: { 'remote-redux-devtools': src } };
+  // Compile from source
+  module.exports.module.loaders.push({
+    test: /\.js$/,
+    loaders: ['babel'],
+    include: src
+  });
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-export const socketOptions = {
+export const defaultSocketOptions = {
   protocol: 'http',
   hostname: 'remotedev.io',
   port: 80,

--- a/src/devTools.js
+++ b/src/devTools.js
@@ -1,13 +1,14 @@
 import { stringify, parse } from 'jsan';
 import socketCluster from 'socketcluster-client';
 import configureStore from './configureStore';
-import { socketOptions } from './constants';
+import { defaultSocketOptions } from './constants';
 
 const monitorActions = [ // To be skipped for relaying actions
   'TOGGLE_ACTION', 'SWEEP', 'IMPORT_STATE', 'SET_ACTIONS_ACTIVE'
 ];
 
 let instanceName;
+let socketOptions;
 let socket;
 let channel;
 let store = {};
@@ -15,6 +16,8 @@ let lastAction;
 let filters;
 let isExcess;
 let isMonitored;
+let startOn;
+let started;
 
 function isFiltered(action) {
   if (!action || !action.action || !action.action.type) return false;
@@ -79,31 +82,41 @@ function handleMessages(message) {
 }
 
 function init(options) {
-  if (channel) channel.unwatch();
-  if (socket) socket.disconnect();
-  if (options && options.port && !options.hostname) {
-    options.hostname = 'localhost';
+  instanceName = options.name;
+  if (options.filters) {
+    filters = options.filters;
   }
-  socket = socketCluster.connect(options && options.port ? options : socketOptions);
+  if (options.port) {
+    socketOptions = {
+      port: options.port,
+      host: options.hostname || 'localhost'
+    };
+  } else socketOptions = defaultSocketOptions;
 
+  startOn = typeof options.startOn === 'string'
+    ? [options.startOn]
+    : options.startOn && options.startOn.length;
+}
+
+function start() {
+  if (started) return;
+  started = true;
+
+  socket = socketCluster.connect(socketOptions);
   socket.on('error', function (err) {
     console.warn(err);
   });
-
   socket.emit('login', 'master', (err, channelName) => {
     if (err) { console.warn(err); return; }
     channel = socket.subscribe(channelName);
     channel.watch(handleMessages);
     socket.on(channelName, handleMessages);
   });
-  if (options && options.filters) {
-    filters = options.filters;
-  }
-  if (options) instanceName = options.name;
   relay('STATE', store.liftedStore.getState());
 }
 
 function monitorReducer(state = {}, action) {
+  if (!started && action.action && startOn.indexOf(action.action.type) !== -1) start();
   lastAction = action.type;
   return state;
 }
@@ -124,10 +137,10 @@ function handleChange(state, liftedState, maxAge) {
 }
 
 export default function devTools(options = {}) {
+  init(options);
   const realtime = typeof options.realtime === 'undefined'
-    ? process.env.NODE_ENV === 'development'
-    : options.realtime;
-  if (!realtime) return f => f;
+    ? process.env.NODE_ENV === 'development' : options.realtime;
+  if (!realtime && !startOn) return f => f;
 
   const maxAge = options.maxAge || 30;
   return (next) => {
@@ -135,7 +148,8 @@ export default function devTools(options = {}) {
       store = configureStore(
         next, monitorReducer, { maxAge }
       )(reducer, initialState);
-      init(options);
+
+      if (realtime) start();
       store.subscribe(() => {
         if (isMonitored) handleChange(store.getState(), store.liftedStore.getState(), maxAge);
       });

--- a/src/devTools.js
+++ b/src/devTools.js
@@ -122,8 +122,14 @@ function start() {
 function stop() {
   started = false;
   isMonitored = false;
-  if (channel) channel.unwatch();
-  if (socket) socket.disconnect();
+  if (channel) {
+    channel.unsubscribe();
+    channel.unwatch();
+  }
+  if (socket) {
+    socket.off();
+    socket.disconnect();
+  }
 }
 
 function monitorReducer(state = {}, action) {

--- a/src/devTools.js
+++ b/src/devTools.js
@@ -123,8 +123,13 @@ function handleChange(state, liftedState, maxAge) {
   }
 }
 
-export default function devTools(options) {
-  const maxAge = options && options.maxAge || 30;
+export default function devTools(options = {}) {
+  const realtime = typeof options.realtime === 'undefined'
+    ? process.env.NODE_ENV === 'development'
+    : options.realtime;
+  if (!realtime) return f => f;
+
+  const maxAge = options.maxAge || 30;
   return (next) => {
     return (reducer, initialState) => {
       store = configureStore(


### PR DESCRIPTION
Use Remote Redux DevTools to monitor your web, React Native or hybrid apps not only in development, but also **in production**! This PR introduces the main functionality for that.

Start or stop monitoring by using specific actions (for example `SOME_ACTION_ERROR`).

**[*Check the demo here*](http://zalmoxisus.github.io/monitoring/)**

It implies that for production you'll host [`remotedev-server`](https://github.com/zalmoxisus/remotedev-server) on your side.

The configuration will be like:
```js
export default function configureStore(initialState) {
 return createStore(
    rootReducer,
    initialState,
    devTools({
      name: 'Android app', realtime: false,
      hostname: 'your-host.com', port: 8000,
      startOn: 'SOME_ACTION_ERROR' // or array: ['LOGIN_ERROR', 'SOME_ACTION_ERROR']
      })
  );
}
```

For development just use `devTools()` as before if `process.env.NODE_ENV === 'development'`, otherwise set `realtime` option to `true` (`devTools({ realtime: true })`).