### PR TITLE
Send information about exceptions for React Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Name                  | Description
 `startOn`             | *String* or *Array of strings* indicating an action or a list of actions, which should start remote monitoring (when `realtime` is `false`). 
 `stopOn`              | *String* or *Array of strings* indicating an action or a list of actions, which should stop remote monitoring. 
 `sendOn`              | *String* or *Array of strings* indicating an action or a list of actions, which should trigger sending the history to the monitor (without starting it). *Note*: when using it, add a `fetch` polyfill if needed.
-`sendOnError`         | *Numeric* code: `0` - disabled (default), `1` - send all uncaught exception messages (for browser and React Native), `2` - send only reducers error messages.
+`sendOnError`         | *Numeric* code: `0` - disabled (default), `1` - send all uncaught exception messages, `2` - send only reducers error messages.
 `sendTo`              | *String* url of the monitor to send the history when `sendOn` is triggered. By default is `${secure ? 'https' : 'http'}://${hostname}:${port}`.
 `id`                  | *String* to identify the instance when sending the history triggered by `sendOn`. You can use, for example, user id here, to know who sent the data.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Name                  | Description
 `startOn`             | *String* or *Array of strings* indicating an action or a list of actions, which should start remote monitoring (when `realtime` is `false`). 
 `stopOn`              | *String* or *Array of strings* indicating an action or a list of actions, which should stop remote monitoring. 
 `sendOn`              | *String* or *Array of strings* indicating an action or a list of actions, which should trigger sending the history to the monitor (without starting it). *Note*: when using it, add a `fetch` polyfill if needed.
-`sendOnError`         | *Numeric* code: `0` - disabled (default), `1` - send all uncaught exception messages (for browser only), `2` - send only reducers error messages.
+`sendOnError`         | *Numeric* code: `0` - disabled (default), `1` - send all uncaught exception messages (for browser and React Native), `2` - send only reducers error messages.
 `sendTo`              | *String* url of the monitor to send the history when `sendOn` is triggered. By default is `${secure ? 'https' : 'http'}://${hostname}:${port}`.
 `id`                  | *String* to identify the instance when sending the history triggered by `sendOn`. You can use, for example, user id here, to know who sent the data.
 

--- a/src/devTools.js
+++ b/src/devTools.js
@@ -119,8 +119,8 @@ function sendError(errorAction) {
 
 function catchErrors() {
   if (typeof window === 'object' && typeof window.onerror === 'object') {
-    window.onerror = function (msg, url, lineNo, columnNo, error) {
-      const errorAction = { type: ERROR, msg, url, lineNo, columnNo };
+    window.onerror = function (message, url, lineNo, columnNo, error) {
+      const errorAction = { type: ERROR, message, url, lineNo, columnNo };
       if (error && error.stack) errorAction.stack = error.stack;
       sendError(errorAction);
       return false;
@@ -129,6 +129,23 @@ function catchErrors() {
     global.ErrorUtils.setGlobalHandler((error, isFatal) => {
       sendError({ type: ERROR, error, isFatal });
     });
+  }
+
+  if (typeof console === 'object' && typeof console.error === 'function' && !console.beforeRemotedev) {
+    console.beforeRemotedev = console.error.bind(console);
+    console.error = function () {
+      let errorAction = { type: ERROR };
+      const error = arguments[0];
+      errorAction.message = error.message ? error.message : error;
+      if (error.sourceURL) {
+        errorAction = {
+          ...errorAction, sourceURL: error.sourceURL, line: error.line, column: error.column
+        };
+      }
+      if (error.stack) errorAction.stack = error.stack;
+      sendError(errorAction);
+      console.beforeRemotedev.apply(null, arguments);
+    };
   }
 }
 


### PR DESCRIPTION
In https://github.com/zalmoxisus/remote-redux-devtools/commit/abeae5315b0b2d465278ca34fd461ee806da9290 I've introduced a new feature, now you can send information about exceptions. This pr is an attempt to implement it for React Native. I didn't test it yet. If someone can look into it, it would be very welcome. Not sure though if it will send fatal errors, as the app wold be blocked in this case.

Another issue is that it overwrites the global error handler, so we should probably use `getGlobalHandler` introduced in https://github.com/facebook/react-native/pull/5575. More details [here](https://github.com/facebook/react-native/issues/1194).