### PR TITLE
Get correctly localhost for React Native

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -2,6 +2,7 @@ import { stringify, parse } from 'jsan';
 import socketCluster from 'socketcluster-client';
 import configureStore from './configureStore';
 import { defaultSocketOptions } from './constants';
+import { getHostForRN } from './utils/reactNative';
 
 const ERROR = '@@remotedev/ERROR';
 
@@ -258,7 +259,10 @@ function handleChange(state, liftedState, maxAge) {
 }
 
 export default function devTools(options = {}) {
-  init(options);
+  init({
+    ...options,
+    hostname: getHostForRN(options.hostname)
+  });
   const realtime = typeof options.realtime === 'undefined'
     ? process.env.NODE_ENV === 'development' : options.realtime;
   if (!realtime && !(startOn || sendOn || sendOnError)) return f => f;

--- a/src/utils/reactNative.js
+++ b/src/utils/reactNative.js
@@ -1,0 +1,20 @@
+/*
+ * Get React Native server IP if hostname is `localhost`
+ * On Android emulator, the IP of host is `10.0.2.2` (Genymotion: 10.0.3.2)
+ */
+export function getHostForRN(hostname) {
+  if (
+    (hostname === 'localhost' || hostname === '127.0.0.1') &&
+    typeof window !== 'undefined' &&
+    window.__fbBatchedBridge &&
+    window.__fbBatchedBridge.RemoteModules &&
+    window.__fbBatchedBridge.RemoteModules.AndroidConstants
+  ) {
+    const {
+      ServerHost = hostname
+    } = window.__fbBatchedBridge.RemoteModules.AndroidConstants;
+    return ServerHost.split(':')[0];
+  }
+
+  return hostname;
+}


### PR DESCRIPTION
Use `NativeModules.AndroidConstants` to get correctly localhost `10.0.2.2` (Genymotion: `10.0.3.2`) for emulator, I used `window. __fbBatchedBridge.RemoteModules` instead of `require('react-native') .NativeModules`, so it will not affect non-RN environments.

It mean we will never need use `adb reverse` for Android emulator. ([Notes](https://github.com/zalmoxisus/remotedev-server#connect-from-android-device-or-emulator))