### PR TITLE
Updated socketcluster-client to version that supports web worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "querystring": "^0.2.0",
     "redux-devtools-instrument": "^1.3.1",
     "remotedev-utils": "0.0.5",
-    "socketcluster-client": "4.3.19"
+    "socketcluster-client": "^5.0.14"
   }
 }


### PR DESCRIPTION
https://github.com/SocketCluster/socketcluster-client/pull/65

This enables the devtools to be run when the whole application is run within a webworker.