### PR TITLE
Check action is array for `relay`

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -57,7 +57,7 @@ function send() {
 }
 
 function relay(type, state, action, nextActionId) {
-  if (isFiltered(action, filters)) return;
+  if (!Array.isArray(action) && isFiltered(action, filters)) return;
   const message = {
     type,
     id: socket.id,


### PR DESCRIPTION
Currently If we use `actionCreators` and `filters` together, it will call `isFiltered(<actionCreators>, filters))` (See [src/devTools.js#L103](https://github.com/zalmoxisus/remote-redux-devtools/blob/master/src/devTools.js#L103)), it will throw `Cannot read property 'match' of undefined` error. (`action.type` is undefined)