### PR TITLE
Fix filters not work if filter more than two actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jsan": "^3.1.3",
     "querystring": "^0.2.0",
     "redux-devtools-instrument": "^1.3.1",
-    "remotedev-utils": "0.0.5",
+    "remotedev-utils": "^0.1.1",
     "socketcluster-client": "^5.0.17"
   }
 }

--- a/src/devTools.js
+++ b/src/devTools.js
@@ -5,7 +5,12 @@ import { defaultSocketOptions } from './constants';
 import { getHostForRN } from './utils/reactNative';
 import { evalAction, getActionsArray } from 'remotedev-utils';
 import catchErrors from 'remotedev-utils/lib/catchErrors';
-import { isFiltered, filterStagedActions, filterState } from 'remotedev-utils/lib/filters';
+import {
+  getLocalFilter,
+  isFiltered,
+  filterStagedActions,
+  filterState
+} from 'remotedev-utils/lib/filters';
 
 let instanceId;
 let instanceName;
@@ -131,13 +136,11 @@ function str2array(str) {
 
 function init(options) {
   instanceName = options.name;
-  if (options.actionsBlacklist) {
-    filters = { blacklist: options.actionsBlacklist };
-  } else if (options.actionsWhitelist) {
-    filters = { whitelist: options.actionsWhitelist };
-  } else if (options.filters) {
-    filters = options.filters;
-  }
+  const { blacklist, whitelist } = options.filters || {};
+  filters = getLocalFilter({
+    actionsBlacklist: blacklist || options.actionsBlacklist,
+    actionsWhitelist: whitelist || options.actionsWhitelist
+  });
   if (options.port) {
     socketOptions = {
       port: options.port,


### PR DESCRIPTION
Use [`getLocalFilter`](https://github.com/zalmoxisus/remotedev-utils/blob/master/src/filters.js#L27) to convert array to regex string, because currently [`isFiltered`](https://github.com/zalmoxisus/remotedev-utils/blob/master/src/filters.js#L51) will to match array:

```js
// got `true`, to match ['ACTION'].toString() => 'ACTION'
!!'ACTION'.match(['ACTION'])

// got `false`, to match ['ACTION', 'ACTION2'].toString() => 'ACTION,ACTION2'
!!'ACTION'.match(['ACTION', 'ACTION2'])

// Change to
!!'ACTION'.match('ACTION|ACTION2')
```