### PR TITLE
Fix getHostForRN for newer React Native versions

### DIFF
--- a/src/utils/reactNative.js
+++ b/src/utils/reactNative.js
@@ -3,18 +3,19 @@
  * On Android emulator, the IP of host is `10.0.2.2` (Genymotion: 10.0.3.2)
  */
 export function getHostForRN(hostname) {
+  const { remoteModuleConfig } = typeof window !== 'undefined' &&
+    window.__fbBatchedBridgeConfig || {};
   if (
-    (hostname === 'localhost' || hostname === '127.0.0.1') &&
-    typeof window !== 'undefined' &&
-    window.__fbBatchedBridge &&
-    window.__fbBatchedBridge.RemoteModules &&
-    window.__fbBatchedBridge.RemoteModules.AndroidConstants
-  ) {
-    const {
-      ServerHost = hostname
-    } = window.__fbBatchedBridge.RemoteModules.AndroidConstants;
+    hostname !== 'localhost' && hostname !== '127.0.0.1' ||
+    !Array.isArray(remoteModuleConfig)
+  ) return hostname;
+
+  const [, AndroidConstants] = remoteModuleConfig.find(config =>
+    config && config[0] === 'AndroidConstants'
+  ) || [];
+  if (AndroidConstants) {
+    const { ServerHost = hostname } = AndroidConstants;
     return ServerHost.split(':')[0];
   }
-
   return hostname;
 }


### PR DESCRIPTION
Related to https://github.com/zalmoxisus/remote-redux-devtools/issues/45#issuecomment-266042357, use `__fbBatchedBridgeConfig ` instead.