### PR TITLE
fixed suppressConnectErrors property check

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -151,7 +151,7 @@ function init(options) {
     };
   } else socketOptions = defaultSocketOptions;
 
-  suppressConnectErrors = options.suppressConnectErrors ? options.suppressConnectErrors : true;
+  suppressConnectErrors = options.suppressConnectErrors !== undefined ? options.suppressConnectErrors : true;
 
   startOn = str2array(options.startOn);
   stopOn = str2array(options.stopOn);


### PR DESCRIPTION
Fixed suppressConnectErrors property check for when option is provided with value `false`.

Fixes #84 