### PR TITLE
Add default hostname for rn-host-detect

### DIFF
--- a/src/devTools.js
+++ b/src/devTools.js
@@ -269,7 +269,7 @@ function handleChange(state, liftedState, maxAge) {
 export default function devToolsEnhancer(options = {}) {
   init({
     ...options,
-    hostname: getHostForRN(options.hostname)
+    hostname: getHostForRN(options.hostname || 'localhost')
   });
   const realtime = typeof options.realtime === 'undefined'
     ? process.env.NODE_ENV === 'development' : options.realtime;


### PR DESCRIPTION
Currently we must set `hostname: 'localhost'` for make `rn-host-detect` convert the hostname successfully for RN Android (it make some issues like #68), I think set the default hostname for `getHostForRN` will be better.