### PR TITLE
Update readme about `remotedev-rn-debugger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const store = createStore(reducer, devToolsEnhancer({ realtime: true }));
 Use one of our monitor apps to inspect and dispatch actions:
 * [web](http://remotedev.io/local)
 * [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension) - Click "Remote" button (or press [`Cmd+Ctrl+Arrow up`](https://github.com/zalmoxisus/redux-devtools-extension#keyboard-shortcuts)) to open remote monitoring.
-* [remote-redux-devtools-on-debugger](https://github.com/jhen0409/remote-redux-devtools-on-debugger) - Used in React Native debugger as a dock monitor.
+* [remotedev-rn-debugger](https://github.com/jhen0409/remotedev-rn-debugger) - Used in React Native debugger as a dock monitor.
 * [atom-redux-devtools](https://github.com/zalmoxisus/atom-redux-devtools) - Used in Atom editor.
 * [redux-dispatch-cli](https://github.com/jhen0409/redux-dispatch-cli) - A CLI tool for Redux remote dispatch.
 * [vscode-redux-devtools](https://github.com/jkzing/vscode-redux-devtools) - Used in Visual Studio Code.
@@ -111,7 +111,7 @@ var remotedev = require('remotedev-server');
 remotedev({ hostname: 'localhost', port: 8000 });
 ```
 See [remotedev-server](https://github.com/zalmoxisus/remotedev-server) repository for more details.
-For React Native you can use [react-native-debugger](https://github.com/jhen0409/react-native-debugger) or [remote-redux-devtools-on-debugger](https://github.com/jhen0409/remote-redux-devtools-on-debugger), which already include `remotedev-server`.
+For React Native you can use [remotedev-rn-debugger](https://github.com/jhen0409/remotedev-rn-debugger), which already include `remotedev-server`.
 
 
 ### Parameters


### PR DESCRIPTION
`remote-redux-devtools-on-debugger` have been renamed to [`remotedev-rn-debugger`](https://github.com/jhen0409/remotedev-rn-debugger).

Also remove `react-native-debugger` mention in `remotedev-server` section to avoid misunderstanding like https://github.com/jhen0409/react-native-debugger/issues/29 as we have yet to support remote API for that. I think move the mention to `redux-devtools-extension` will be better.