### PR TITLE
Update package.json to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "redux-devtools-instrument": "^1.3.3",
     "remotedev-utils": "^0.1.1",
     "rn-host-detect": "^1.0.1",
-    "socketcluster-client": "^5.3.1"
+    "socketcluster-client": "^13.0.0"
   }
 }


### PR DESCRIPTION
upgrading socketcluster-client from version 5.3.1 to 13.0.0 will remove an older dependency on "ws" which has a denial of service vulnerability. Making this change will solve issues #116 and #119, which have more detail on this issue. Personally, I'm just trying to get the gatsby v2 beta up and running on my local machine. Hope you have a great day!